### PR TITLE
Improve error handling in crew executor

### DIFF
--- a/crew/crew_executor.py
+++ b/crew/crew_executor.py
@@ -198,5 +198,9 @@ async def execute_crew(
         else:
             logger.warning(f"Resultado do Crew '{crew_name}' (após conversão e strip) é vazio ou None, não será salvo no Zep.")
         return crew_result_text
-    except ValueError as ve: raise
-    except Exception as e: raise
+    except ValueError as ve:
+        logger.error(f"Erro de valor ao executar crew '{crew_name}': {ve}")
+        raise ve
+    except Exception as e:
+        logger.error(f"Erro inesperado ao executar crew '{crew_name}': {e}", exc_info=True)
+        raise e


### PR DESCRIPTION
## Summary
- improve exception handling in `crew_executor`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_683fc35002a08331a70e5d78d57fa3a7