### PR TITLE
Fix missing message handling

### DIFF
--- a/crew/crew_executor.py
+++ b/crew/crew_executor.py
@@ -121,7 +121,9 @@ async def execute_crew(
         except NotFoundError:
             await zep_client.memory.add_session(session_id=session_id, user_id=user_id)
 
-        user_message_content = inputs["message"]
+        user_message_content = inputs.get("message")
+        if not user_message_content:
+            raise ValueError("Campo 'message' é obrigatório nos inputs.")
         query_for_graph = user_message_content
 
         # Bloco 2: Adicionar mensagem atual do usuário à memória Zep


### PR DESCRIPTION
## Summary
- raise a ValueError if `execute_crew` receives inputs without `message`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_683fc35db3908331bcfe0bf814bcb304